### PR TITLE
Correction de la fonction de chargement du style.css du thème parent

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -4,5 +4,5 @@
 add_action('wp_enqueue_scripts', 'theme_enqueue_styles');
 function theme_enqueue_styles(){
     // Chargement du style.css du thème parent Twenty Twenty
-    wp_enqueue_style('parent-style', get_template_directory_uri() . '/style.css');
+    wp_enqueue_style('parent-style', get_parent_theme_file_uri('style.css'));
 }


### PR DESCRIPTION
get_template_directory_uri() retourne en effet l'URI du thème actif qui est ici le thème enfant, tandis que get_parent_theme_file_uri( 'style.css' ) retourne l'URL du fichier style.css du thème parent.